### PR TITLE
refactor: Modularize ProfileTab component into reusable components

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -22,7 +22,8 @@
         "tailwindcss": "^4.1.14",
         "tw-animate-css": "^1.4.0",
         "vue": "^3.5.22",
-        "vue-router": "^4.5.1"
+        "vue-router": "^4.5.1",
+        "vue-sonner": "^2.0.9"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -7245,6 +7246,28 @@
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
       "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
       "license": "MIT"
+    },
+    "node_modules/vue-sonner": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/vue-sonner/-/vue-sonner-2.0.9.tgz",
+      "integrity": "sha512-i6BokNlNDL93fpzNxN/LZSn6D6MzlO+i3qXt6iVZne3x1k7R46d5HlFB4P8tYydhgqOrRbIZEsnRd3kG7qGXyw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nuxt/kit": "^4.0.3",
+        "@nuxt/schema": "^4.0.3",
+        "nuxt": "^4.0.3"
+      },
+      "peerDependenciesMeta": {
+        "@nuxt/kit": {
+          "optional": true
+        },
+        "@nuxt/schema": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        }
+      }
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -30,7 +30,8 @@
     "tailwindcss": "^4.1.14",
     "tw-animate-css": "^1.4.0",
     "vue": "^3.5.22",
-    "vue-router": "^4.5.1"
+    "vue-router": "^4.5.1",
+    "vue-sonner": "^2.0.9"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,6 +1,8 @@
 <script setup>
 import { useSEO } from '@/composables/useSEO'
 import GlobalLoader from '@/components/common/GlobalLoader.vue'
+import { Toaster } from '@/components/ui/sonner'
+import 'vue-sonner/style.css'
 
 // Default SEO configuration for the entire app
 useSEO({
@@ -15,5 +17,6 @@ useSEO({
   <div id="app">
     <router-view></router-view>
     <GlobalLoader />
+    <Toaster rich-colors />
   </div>
 </template>

--- a/client/src/api/auth.js
+++ b/client/src/api/auth.js
@@ -48,6 +48,12 @@ export const authAPI = {
   logout: async () => {
     const response = await api.post('/auth/logout')
     return response.data
+  },
+
+  // Update user profile
+  updateProfile: async (profileData) => {
+    const response = await api.patch('/user/profile', profileData)
+    return response.data
   }
 }
 

--- a/client/src/components/ui/sonner/Sonner.vue
+++ b/client/src/components/ui/sonner/Sonner.vue
@@ -1,0 +1,19 @@
+<script lang="ts" setup>
+import type { ToasterProps } from "vue-sonner"
+import { Toaster as Sonner } from "vue-sonner"
+
+const props = defineProps<ToasterProps>()
+</script>
+
+<template>
+  <Sonner
+    class="toaster group"
+    v-bind="props"
+    :style="{
+      '--normal-bg': 'var(--popover)',
+      '--normal-text': 'var(--popover-foreground)',
+      '--normal-border': 'var(--border)',
+
+    }"
+  />
+</template>

--- a/client/src/components/ui/sonner/index.ts
+++ b/client/src/components/ui/sonner/index.ts
@@ -1,0 +1,1 @@
+export { default as Toaster } from "./Sonner.vue"

--- a/client/src/components/views/DashboardNavbar.vue
+++ b/client/src/components/views/DashboardNavbar.vue
@@ -86,7 +86,7 @@ const handleLogout = () => {
               size="default"
             />
             <div class="hidden md:flex flex-col items-start text-left">
-              <span class="text-sm font-medium">{{ authStore.userEmail }}</span>
+              <span class="text-sm font-medium">{{authStore.userName || authStore.userEmail }}</span>
               <span class="text-xs text-muted-foreground">{{ displayRole }}</span>
             </div>
             <ChevronDown class="h-4 w-4 text-muted-foreground" />

--- a/client/src/components/views/UserAvatar.vue
+++ b/client/src/components/views/UserAvatar.vue
@@ -30,7 +30,7 @@ const avatarUrl = computed(() => {
   
   // Use DiceBear API with the email as seed for consistent avatars
   const seed = encodeURIComponent(props.email)
-  return `https://api.dicebear.com/9.x/avataaars-neutral/svg?seed=${seed}`
+  return `https://api.dicebear.com/9.x/thumbs/svg?seed=${seed}`
 })
 
 // Get user initials as fallback

--- a/client/src/components/views/profile/EditProfileDialog.vue
+++ b/client/src/components/views/profile/EditProfileDialog.vue
@@ -1,0 +1,436 @@
+<script setup>
+import { ref, computed, watch } from 'vue'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Separator } from '@/components/ui/separator'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  Mail,
+  MapPin,
+  User,
+  Loader2,
+} from 'lucide-vue-next'
+
+// Import Philippine address data
+import regionsData from '@/lib/ph-json/region.json'
+import provincesData from '@/lib/ph-json/province.json'
+import citiesData from '@/lib/ph-json/city.json'
+import barangaysData from '@/lib/ph-json/barangay.json'
+
+const props = defineProps({
+  open: {
+    type: Boolean,
+    required: true
+  },
+  user: {
+    type: Object,
+    required: true
+  },
+  isSaving: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const emit = defineEmits(['update:open', 'save', 'cancel'])
+
+// Form state
+const editForm = ref({
+  name: '',
+  email: '',
+  street: '',
+})
+
+// Form errors
+const formErrors = ref({
+  name: '',
+})
+
+// Address selection state
+const selectedRegion = ref('')
+const selectedProvince = ref('')
+const selectedCity = ref('')
+const selectedBarangay = ref('')
+const isLoadingAddress = ref(false)
+
+// Filtered address data
+const filteredProvinces = computed(() => {
+  if (!selectedRegion.value) return []
+  return provincesData.filter(p => p.region_code === selectedRegion.value)
+})
+
+const filteredCities = computed(() => {
+  if (!selectedProvince.value) return []
+  return citiesData.filter(c => c.province_code === selectedProvince.value)
+})
+
+const filteredBarangays = computed(() => {
+  if (!selectedCity.value) return []
+  return barangaysData.filter(b => b.city_code === selectedCity.value)
+})
+
+// Watchers with loading guard
+watch(selectedRegion, () => {
+  if (isLoadingAddress.value) return
+  selectedProvince.value = ''
+  selectedCity.value = ''
+  selectedBarangay.value = ''
+})
+
+watch(selectedProvince, () => {
+  if (isLoadingAddress.value) return
+  selectedCity.value = ''
+  selectedBarangay.value = ''
+})
+
+watch(selectedCity, () => {
+  if (isLoadingAddress.value) return
+  selectedBarangay.value = ''
+})
+
+// Watch for dialog open to populate form
+watch(() => props.open, (isOpen) => {
+  if (isOpen) {
+    populateForm()
+  }
+})
+
+// Helper to find address codes from names
+const findAddressCodes = () => {
+  let regionCode = ''
+  let provinceCode = ''
+  let cityCode = ''
+  let barangayCode = ''
+
+  if (props.user.region) {
+    const region = regionsData.find(r => r.region_name === props.user.region)
+    if (region) regionCode = region.region_code
+  }
+
+  if (props.user.province && regionCode) {
+    const province = provincesData.find(p => 
+      p.province_name === props.user.province && p.region_code === regionCode
+    )
+    if (province) provinceCode = province.province_code
+  }
+
+  if (props.user.city && provinceCode) {
+    const city = citiesData.find(c => 
+      c.city_name === props.user.city && c.province_code === provinceCode
+    )
+    if (city) cityCode = city.city_code
+  }
+
+  if (props.user.barangay && cityCode) {
+    const barangay = barangaysData.find(b => 
+      b.brgy_name === props.user.barangay && b.city_code === cityCode
+    )
+    if (barangay) barangayCode = barangay.brgy_code
+  }
+
+  return { regionCode, provinceCode, cityCode, barangayCode }
+}
+
+// Populate form with user data
+const populateForm = () => {
+  editForm.value = {
+    name: props.user.name || '',
+    email: props.user.email || '',
+    street: props.user.street || '',
+  }
+  
+  formErrors.value = { name: '' }
+  
+  // Load address with guard
+  isLoadingAddress.value = true
+  const { regionCode, provinceCode, cityCode, barangayCode } = findAddressCodes()
+  selectedRegion.value = regionCode
+  selectedProvince.value = provinceCode
+  selectedCity.value = cityCode
+  selectedBarangay.value = barangayCode
+  
+  setTimeout(() => {
+    isLoadingAddress.value = false
+  }, 0)
+}
+
+// Validation
+const validateForm = () => {
+  formErrors.value = { name: '' }
+  
+  if (!editForm.value.name || editForm.value.name.trim().length === 0) {
+    formErrors.value.name = 'Name is required'
+    return false
+  }
+  
+  if (editForm.value.name.trim().length < 2) {
+    formErrors.value.name = 'Name must be at least 2 characters long'
+    return false
+  }
+  
+  return true
+}
+
+// Check address completion
+const checkAddressCompletion = () => {
+  const hasAny = selectedRegion.value || selectedProvince.value || selectedCity.value || selectedBarangay.value
+  const hasComplete = selectedRegion.value && selectedProvince.value && selectedCity.value && selectedBarangay.value
+  return { hasAny, hasComplete }
+}
+
+// Handle save
+const handleSave = () => {
+  if (!validateForm()) {
+    emit('save', { 
+      isValid: false, 
+      error: formErrors.value.name 
+    })
+    return
+  }
+
+  const { hasAny, hasComplete } = checkAddressCompletion()
+  
+  if (hasAny && !hasComplete) {
+    emit('save', { 
+      isValid: false, 
+      error: 'Please complete all address fields (Region, Province, City, and Barangay) or leave them all empty',
+      type: 'address'
+    })
+    return
+  }
+
+  // Build profile data
+  let profileData = {
+    name: editForm.value.name.trim(),
+    street: editForm.value.street?.trim() || null,
+  }
+
+  if (hasComplete) {
+    const region = regionsData.find(r => r.region_code === selectedRegion.value)
+    const province = provincesData.find(p => p.province_code === selectedProvince.value)
+    const city = citiesData.find(c => c.city_code === selectedCity.value)
+    const barangay = barangaysData.find(b => b.brgy_code === selectedBarangay.value)
+
+    profileData = {
+      ...profileData,
+      region: region?.region_name || null,
+      province: province?.province_name || null,
+      city: city?.city_name || null,
+      barangay: barangay?.brgy_name || null,
+    }
+  } else {
+    profileData = {
+      ...profileData,
+      region: null,
+      province: null,
+      city: null,
+      barangay: null,
+    }
+  }
+
+  emit('save', { isValid: true, data: profileData })
+}
+
+const handleCancel = () => {
+  emit('cancel')
+}
+
+const handleOpenChange = (value) => {
+  emit('update:open', value)
+}
+</script>
+
+<template>
+  <Dialog :open="open" @update:open="handleOpenChange">
+    <DialogContent class="sm:max-w-[600px]">
+      <DialogHeader>
+        <DialogTitle>Edit Profile</DialogTitle>
+        <DialogDescription>
+          Update your personal information and address details
+        </DialogDescription>
+      </DialogHeader>
+
+      <div class="space-y-4 py-4">
+        <!-- Name Field -->
+        <div class="space-y-2">
+          <Label for="edit-name">Full Name <span class="text-red-500">*</span></Label>
+          <div class="relative">
+            <User class="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              id="edit-name"
+              v-model="editForm.name"
+              placeholder="Enter your full name"
+              class="pl-10"
+              :class="{ 'border-red-500': formErrors.name }"
+            />
+          </div>
+          <p v-if="formErrors.name" class="text-xs text-red-500">
+            {{ formErrors.name }}
+          </p>
+        </div>
+
+        <!-- Email Field (Read-only) -->
+        <div class="space-y-2">
+          <Label for="edit-email">Email Address</Label>
+          <div class="relative">
+            <Mail class="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              id="edit-email"
+              v-model="editForm.email"
+              type="email"
+              disabled
+              class="pl-10 bg-muted"
+            />
+          </div>
+          <p class="text-xs text-muted-foreground">Email cannot be changed</p>
+        </div>
+
+        <Separator />
+
+        <!-- Address Fields -->
+        <div class="space-y-4">
+          <div class="flex items-center gap-2">
+            <MapPin class="h-4 w-4 text-muted-foreground" />
+            <h4 class="text-sm font-medium">Address Information</h4>
+          </div>
+
+          <div class="grid gap-4 sm:grid-cols-2">
+            <!-- Region Selection -->
+            <div class="space-y-2">
+              <Label for="edit-region">Region</Label>
+              <Select v-model="selectedRegion">
+                <SelectTrigger id="edit-region">
+                  <SelectValue placeholder="Select region" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    <SelectLabel>Philippine Regions</SelectLabel>
+                    <SelectItem 
+                      v-for="region in regionsData" 
+                      :key="region.region_code"
+                      :value="region.region_code"
+                    >
+                      {{ region.region_name }}
+                    </SelectItem>
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <!-- Province Selection -->
+            <div class="space-y-2">
+              <Label for="edit-province">Province</Label>
+              <Select v-model="selectedProvince" :disabled="!selectedRegion">
+                <SelectTrigger id="edit-province">
+                  <SelectValue placeholder="Select province" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    <SelectLabel>Provinces</SelectLabel>
+                    <SelectItem 
+                      v-for="province in filteredProvinces" 
+                      :key="province.province_code"
+                      :value="province.province_code"
+                    >
+                      {{ province.province_name }}
+                    </SelectItem>
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+              <p v-if="!selectedRegion" class="text-xs text-muted-foreground">
+                Select a region first
+              </p>
+            </div>
+
+            <!-- City/Municipality Selection -->
+            <div class="space-y-2">
+              <Label for="edit-city">City/Municipality</Label>
+              <Select v-model="selectedCity" :disabled="!selectedProvince">
+                <SelectTrigger id="edit-city">
+                  <SelectValue placeholder="Select city/municipality" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    <SelectLabel>Cities/Municipalities</SelectLabel>
+                    <SelectItem 
+                      v-for="city in filteredCities" 
+                      :key="city.city_code"
+                      :value="city.city_code"
+                    >
+                      {{ city.city_name }}
+                    </SelectItem>
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+              <p v-if="!selectedProvince" class="text-xs text-muted-foreground">
+                Select a province first
+              </p>
+            </div>
+
+            <!-- Barangay Selection -->
+            <div class="space-y-2">
+              <Label for="edit-barangay">Barangay</Label>
+              <Select v-model="selectedBarangay" :disabled="!selectedCity">
+                <SelectTrigger id="edit-barangay">
+                  <SelectValue placeholder="Select barangay" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    <SelectLabel>Barangays</SelectLabel>
+                    <SelectItem 
+                      v-for="barangay in filteredBarangays" 
+                      :key="barangay.brgy_code"
+                      :value="barangay.brgy_code"
+                    >
+                      {{ barangay.brgy_name }}
+                    </SelectItem>
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+              <p v-if="!selectedCity" class="text-xs text-muted-foreground">
+                Select a city/municipality first
+              </p>
+            </div>
+
+            <!-- Street Address -->
+            <div class="space-y-2 sm:col-span-2">
+              <Label for="edit-street">Street Address</Label>
+              <Input
+                id="edit-street"
+                v-model="editForm.street"
+                placeholder="Enter house/building number and street name"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <DialogFooter>
+        <Button variant="outline" @click="handleCancel" :disabled="isSaving">
+          Cancel
+        </Button>
+        <Button @click="handleSave" :disabled="isSaving">
+          <Loader2 v-if="isSaving" class="mr-2 h-4 w-4 animate-spin" />
+          {{ isSaving ? 'Saving...' : 'Save Changes' }}
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+</template>

--- a/client/src/components/views/profile/ProfileDisplay.vue
+++ b/client/src/components/views/profile/ProfileDisplay.vue
@@ -1,0 +1,175 @@
+<script setup>
+import { computed } from 'vue'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Separator } from '@/components/ui/separator'
+import { Badge } from '@/components/ui/badge'
+import UserAvatar from '@/components/views/UserAvatar.vue'
+import {
+  Mail,
+  Shield,
+  Calendar,
+  Edit,
+  CheckCircle,
+  MapPin,
+} from 'lucide-vue-next'
+
+const props = defineProps({
+  user: {
+    type: Object,
+    required: true
+  }
+})
+
+const emit = defineEmits(['edit'])
+
+// Format role for display
+const displayRole = computed(() => {
+  const role = props.user.role || 'user'
+  return role.charAt(0).toUpperCase() + role.slice(1)
+})
+
+// Format joined date
+const joinedDate = computed(() => {
+  const date = props.user.createdAt ? new Date(props.user.createdAt) : new Date()
+  return date.toLocaleDateString('en-US', { 
+    year: 'numeric', 
+    month: 'long', 
+    day: 'numeric' 
+  })
+})
+
+const handleEdit = () => {
+  emit('edit')
+}
+</script>
+
+<template>
+  <Card>
+    <CardHeader>
+      <CardTitle>Profile Information</CardTitle>
+      <CardDescription>
+        Your personal information and account details
+      </CardDescription>
+    </CardHeader>
+    <CardContent class="space-y-6">
+      <!-- Avatar Section -->
+      <div class="flex items-center gap-6">
+        <UserAvatar 
+          :email="user.email" 
+          :profile-picture="user.profilePicture"
+          size="lg"
+          class="h-20 w-20"
+        />
+        <div class="space-y-1">
+          <h3 class="text-lg font-semibold">
+            {{ user.name || user.email?.split('@')[0] }}
+          </h3>
+          <p class="text-sm text-muted-foreground">
+            {{ user.email }}
+          </p>
+          <Badge variant="outline" class="bg-primary/10 text-primary border-primary/20">
+            {{ displayRole }}
+          </Badge>
+        </div>
+      </div>
+
+      <Separator />
+
+      <!-- User Details -->
+      <div class="grid gap-6 sm:grid-cols-2">
+        <div class="space-y-2">
+          <div class="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+            <Mail class="h-4 w-4" />
+            Email Address
+          </div>
+          <p class="text-sm font-medium">{{ user.email }}</p>
+        </div>
+
+        <div class="space-y-2">
+          <div class="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+            <Shield class="h-4 w-4" />
+            Role
+          </div>
+          <p class="text-sm font-medium">{{ displayRole }}</p>
+        </div>
+
+        <div class="space-y-2">
+          <div class="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+            <Calendar class="h-4 w-4" />
+            Member Since
+          </div>
+          <p class="text-sm font-medium">{{ joinedDate }}</p>
+        </div>
+
+        <div class="space-y-2">
+          <div class="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+            <CheckCircle class="h-4 w-4" />
+            Account Status
+          </div>
+          <Badge variant="outline" class="bg-green-50 text-green-700 border-green-200">
+            <div class="w-1.5 h-1.5 bg-green-500 rounded-full mr-1.5"></div>
+            Active
+          </Badge>
+        </div>
+      </div>
+
+      <Separator />
+
+      <!-- Address Section -->
+      <div>
+        <div class="flex items-center gap-2 text-sm font-medium text-muted-foreground mb-4">
+          <MapPin class="h-4 w-4" />
+          Address
+        </div>
+        
+        <div class="grid gap-4 sm:grid-cols-2">
+          <div class="space-y-1">
+            <p class="text-xs font-medium text-muted-foreground">Region</p>
+            <p class="text-sm font-medium">
+              {{ user.region || 'Not provided' }}
+            </p>
+          </div>
+
+          <div class="space-y-1">
+            <p class="text-xs font-medium text-muted-foreground">Province</p>
+            <p class="text-sm font-medium">
+              {{ user.province || 'Not provided' }}
+            </p>
+          </div>
+
+          <div class="space-y-1">
+            <p class="text-xs font-medium text-muted-foreground">City/Municipality</p>
+            <p class="text-sm font-medium">
+              {{ user.city || 'Not provided' }}
+            </p>
+          </div>
+
+          <div class="space-y-1">
+            <p class="text-xs font-medium text-muted-foreground">Barangay</p>
+            <p class="text-sm font-medium">
+              {{ user.barangay || 'Not provided' }}
+            </p>
+          </div>
+
+          <div class="space-y-1 sm:col-span-2">
+            <p class="text-xs font-medium text-muted-foreground">Street Address</p>
+            <p class="text-sm font-medium">
+              {{ user.street || 'Not provided' }}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <Separator />
+
+      <!-- Actions -->
+      <div class="flex justify-end">
+        <Button @click="handleEdit" class="gap-2">
+          <Edit class="h-4 w-4" />
+          Edit Profile
+        </Button>
+      </div>
+    </CardContent>
+  </Card>
+</template>

--- a/client/src/components/views/profile/ProfileTab.vue
+++ b/client/src/components/views/profile/ProfileTab.vue
@@ -1,164 +1,78 @@
 <script setup>
-import { ref, computed, watch } from 'vue'
+import { ref, computed } from 'vue'
 import { useAuthStore } from '@/stores/auth'
+import { authAPI } from '@/api/auth'
+import { toast } from 'vue-sonner'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { Separator } from '@/components/ui/separator'
-import { Badge } from '@/components/ui/badge'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectLabel,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
-import UserAvatar from '@/components/views/UserAvatar.vue'
-import {
-  Mail,
-  Shield,
-  Calendar,
-  Edit,
-  CheckCircle,
-  MapPin,
-  User,
-} from 'lucide-vue-next'
-
-// Import Philippine address data
-import regionsData from '@/lib/ph-json/region.json'
-import provincesData from '@/lib/ph-json/province.json'
-import citiesData from '@/lib/ph-json/city.json'
-import barangaysData from '@/lib/ph-json/barangay.json'
+import ProfileDisplay from './ProfileDisplay.vue'
+import EditProfileDialog from './EditProfileDialog.vue'
 
 const authStore = useAuthStore()
 
 // Dialog state
 const isEditDialogOpen = ref(false)
+const isSaving = ref(false)
 
-// Address selection state
-const selectedRegion = ref('')
-const selectedProvince = ref('')
-const selectedCity = ref('')
-const selectedBarangay = ref('')
+// User data computed
+const user = computed(() => ({
+  name: authStore.userName,
+  email: authStore.userEmail,
+  role: authStore.userRole,
+  createdAt: authStore.createdAt,
+  profilePicture: authStore.profilePicture,
+  region: authStore.region,
+  province: authStore.province,
+  city: authStore.city,
+  barangay: authStore.barangay,
+  street: authStore.street,
+}))
 
-// Filtered address data based on selections
-const filteredProvinces = computed(() => {
-  if (!selectedRegion.value) return []
-  return provincesData.filter(p => p.region_code === selectedRegion.value)
-})
-
-const filteredCities = computed(() => {
-  if (!selectedProvince.value) return []
-  return citiesData.filter(c => c.province_code === selectedProvince.value)
-})
-
-const filteredBarangays = computed(() => {
-  if (!selectedCity.value) return []
-  return barangaysData.filter(b => b.city_code === selectedCity.value)
-})
-
-// Watch for address changes and reset dependent selections
-watch(selectedRegion, () => {
-  selectedProvince.value = ''
-  selectedCity.value = ''
-  selectedBarangay.value = ''
-})
-
-watch(selectedProvince, () => {
-  selectedCity.value = ''
-  selectedBarangay.value = ''
-})
-
-watch(selectedCity, () => {
-  selectedBarangay.value = ''
-})
-
-// Form state for editing
-const editForm = ref({
-  name: authStore.userName || '',
-  email: authStore.userEmail || '',
-  street: authStore.street || '',
-  city: authStore.city || '',
-  province: authStore.province || '',
-  country: authStore.country || 'Philippines',
-})
-
-// Format role for display
-const displayRole = computed(() => {
-  const role = authStore.userRole || 'user'
-  return role.charAt(0).toUpperCase() + role.slice(1)
-})
-
-// Format joined date
-const joinedDate = computed(() => {
-  const date = authStore.createdAt ? new Date(authStore.createdAt) : new Date()
-  return date.toLocaleDateString('en-US', { 
-    year: 'numeric', 
-    month: 'long', 
-    day: 'numeric' 
-  })
-})
-
-// Actions
-const handleEditProfile = () => {
-  // Populate form with current data
-  editForm.value = {
-    name: authStore.userName || '',
-    email: authStore.userEmail || '',
-    street: authStore.street || '',
-    city: authStore.city || '',
-    province: authStore.province || '',
-    country: authStore.country || 'Philippines',
-  }
-  
-  // Reset address selections when opening dialog
-  selectedRegion.value = ''
-  selectedProvince.value = ''
-  selectedCity.value = ''
-  selectedBarangay.value = ''
-  
+// Handlers
+const handleEditClick = () => {
   isEditDialogOpen.value = true
 }
 
-const handleSaveProfile = () => {
-  // Update form with selected address data
-  const region = regionsData.find(r => r.region_code === selectedRegion.value)
-  const province = provincesData.find(p => p.province_code === selectedProvince.value)
-  const city = citiesData.find(c => c.city_code === selectedCity.value)
-  const barangay = barangaysData.find(b => b.brgy_code === selectedBarangay.value)
-  
-  // Construct the full address
-  const addressParts = [
-    barangay?.brgy_name,
-    city?.city_name,
-    province?.province_name,
-    region?.region_name
-  ].filter(Boolean)
-  
-  // Update editForm with new address values
-  editForm.value.province = province?.province_name || ''
-  editForm.value.city = city?.city_name || ''
-  
-  // To be implemented - will call API to update profile
-  console.log('Saving profile:', {
-    ...editForm.value,
-    region: region?.region_name,
-    barangay: barangay?.brgy_name,
-    fullAddress: addressParts.join(', ')
-  })
-  
-  isEditDialogOpen.value = false
+const handleSaveProfile = async ({ isValid, data, error, type }) => {
+  if (!isValid) {
+    if (type === 'address') {
+      toast.error('Incomplete Address', {
+        description: error
+      })
+    } else {
+      toast.error('Validation Error', {
+        description: error
+      })
+    }
+    return
+  }
+
+  try {
+    isSaving.value = true
+
+    // Call API to update profile
+    const response = await authAPI.updateProfile(data)
+
+    // Update auth store with new data
+    authStore.updateProfile(response.user)
+
+    // Show success toast
+    toast.success('Profile Updated', {
+      description: 'Your profile has been updated successfully'
+    })
+
+    // Close dialog
+    isEditDialogOpen.value = false
+  } catch (error) {
+    console.error('Failed to update profile:', error)
+    
+    // Show error toast
+    const errorMessage = error.response?.data?.error || 'Failed to update profile. Please try again.'
+    toast.error('Update Failed', {
+      description: errorMessage
+    })
+  } finally {
+    isSaving.value = false
+  }
 }
 
 const handleCancelEdit = () => {
@@ -175,290 +89,18 @@ const handleCancelEdit = () => {
           Your personal information and account details
         </CardDescription>
       </CardHeader>
-      <CardContent class="space-y-6">
-        <!-- Avatar Section -->
-        <div class="flex items-center gap-6">
-          <UserAvatar 
-            :email="authStore.userEmail" 
-            :profile-picture="authStore.profilePicture"
-            size="lg"
-            class="h-20 w-20"
-          />
-          <div class="space-y-1">
-            <h3 class="text-lg font-semibold">
-              {{ authStore.userName || authStore.userEmail?.split('@')[0] }}
-            </h3>
-            <p class="text-sm text-muted-foreground">
-              {{ authStore.userEmail }}
-            </p>
-            <Badge variant="outline" class="bg-primary/10 text-primary border-primary/20">
-              {{ displayRole }}
-            </Badge>
-          </div>
-        </div>
-
-        <Separator />
-
-        <!-- User Details -->
-        <div class="grid gap-6 sm:grid-cols-2">
-          <div class="space-y-2">
-            <div class="flex items-center gap-2 text-sm font-medium text-muted-foreground">
-              <Mail class="h-4 w-4" />
-              Email Address
-            </div>
-            <p class="text-sm font-medium">{{ authStore.userEmail }}</p>
-          </div>
-
-          <div class="space-y-2">
-            <div class="flex items-center gap-2 text-sm font-medium text-muted-foreground">
-              <Shield class="h-4 w-4" />
-              Role
-            </div>
-            <p class="text-sm font-medium">{{ displayRole }}</p>
-          </div>
-
-          <div class="space-y-2">
-            <div class="flex items-center gap-2 text-sm font-medium text-muted-foreground">
-              <Calendar class="h-4 w-4" />
-              Member Since
-            </div>
-            <p class="text-sm font-medium">{{ joinedDate }}</p>
-          </div>
-
-          <div class="space-y-2">
-            <div class="flex items-center gap-2 text-sm font-medium text-muted-foreground">
-              <CheckCircle class="h-4 w-4" />
-              Account Status
-            </div>
-            <Badge variant="outline" class="bg-green-50 text-green-700 border-green-200">
-              <div class="w-1.5 h-1.5 bg-green-500 rounded-full mr-1.5"></div>
-              Active
-            </Badge>
-          </div>
-        </div>
-
-        <Separator />
-
-        <!-- Address Section -->
-        <div>
-          <div class="flex items-center gap-2 text-sm font-medium text-muted-foreground mb-4">
-            <MapPin class="h-4 w-4" />
-            Address
-          </div>
-          
-          <div class="grid gap-4 sm:grid-cols-2">
-            <div class="space-y-1">
-              <p class="text-xs font-medium text-muted-foreground">Street</p>
-              <p class="text-sm font-medium">
-                {{ authStore.street || 'Not provided' }}
-              </p>
-            </div>
-
-            <div class="space-y-1">
-              <p class="text-xs font-medium text-muted-foreground">City</p>
-              <p class="text-sm font-medium">
-                {{ authStore.city || 'Not provided' }}
-              </p>
-            </div>
-
-            <div class="space-y-1">
-              <p class="text-xs font-medium text-muted-foreground">Province</p>
-              <p class="text-sm font-medium">
-                {{ authStore.province || 'Not provided' }}
-              </p>
-            </div>
-
-            <div class="space-y-1">
-              <p class="text-xs font-medium text-muted-foreground">Country</p>
-              <p class="text-sm font-medium">
-                {{ authStore.country || 'Philippines' }}
-              </p>
-            </div>
-          </div>
-        </div>
-
-        <Separator />
-
-        <!-- Actions -->
-        <div class="flex justify-end">
-          <Button @click="handleEditProfile" class="gap-2">
-            <Edit class="h-4 w-4" />
-            Edit Profile
-          </Button>
-        </div>
+      <CardContent>
+        <ProfileDisplay :user="user" @edit="handleEditClick" />
       </CardContent>
     </Card>
 
     <!-- Edit Profile Dialog -->
-    <Dialog v-model:open="isEditDialogOpen">
-      <DialogContent class="sm:max-w-[600px]">
-        <DialogHeader>
-          <DialogTitle>Edit Profile</DialogTitle>
-          <DialogDescription>
-            Update your personal information and address details
-          </DialogDescription>
-        </DialogHeader>
-
-        <div class="space-y-4 py-4">
-          <!-- Name Field -->
-          <div class="space-y-2">
-            <Label for="edit-name">Full Name</Label>
-            <div class="relative">
-              <User class="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-              <Input
-                id="edit-name"
-                v-model="editForm.name"
-                placeholder="Enter your full name"
-                class="pl-10"
-              />
-            </div>
-          </div>
-
-          <!-- Email Field (Read-only) -->
-          <div class="space-y-2">
-            <Label for="edit-email">Email Address</Label>
-            <div class="relative">
-              <Mail class="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-              <Input
-                id="edit-email"
-                v-model="editForm.email"
-                type="email"
-                disabled
-                class="pl-10 bg-muted"
-              />
-            </div>
-            <p class="text-xs text-muted-foreground">Email cannot be changed</p>
-          </div>
-
-          <Separator />
-
-          <!-- Address Fields -->
-          <div class="space-y-4">
-            <div class="flex items-center gap-2">
-              <MapPin class="h-4 w-4 text-muted-foreground" />
-              <h4 class="text-sm font-medium">Address Information</h4>
-            </div>
-
-            <div class="grid gap-4 sm:grid-cols-2">
-              <!-- Region Selection -->
-              <div class="space-y-2">
-                <Label for="edit-region">Region</Label>
-                <Select v-model="selectedRegion">
-                  <SelectTrigger id="edit-region">
-                    <SelectValue placeholder="Select region" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectGroup>
-                      <SelectLabel>Philippine Regions</SelectLabel>
-                      <SelectItem 
-                        v-for="region in regionsData" 
-                        :key="region.region_code"
-                        :value="region.region_code"
-                      >
-                        {{ region.region_name }}
-                      </SelectItem>
-                    </SelectGroup>
-                  </SelectContent>
-                </Select>
-              </div>
-
-              <!-- Province Selection -->
-              <div class="space-y-2">
-                <Label for="edit-province">Province</Label>
-                <Select v-model="selectedProvince" :disabled="!selectedRegion">
-                  <SelectTrigger id="edit-province">
-                    <SelectValue placeholder="Select province" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectGroup>
-                      <SelectLabel>Provinces</SelectLabel>
-                      <SelectItem 
-                        v-for="province in filteredProvinces" 
-                        :key="province.province_code"
-                        :value="province.province_code"
-                      >
-                        {{ province.province_name }}
-                      </SelectItem>
-                    </SelectGroup>
-                  </SelectContent>
-                </Select>
-                <p v-if="!selectedRegion" class="text-xs text-muted-foreground">
-                  Select a region first
-                </p>
-              </div>
-
-              <!-- City/Municipality Selection -->
-              <div class="space-y-2">
-                <Label for="edit-city">City/Municipality</Label>
-                <Select v-model="selectedCity" :disabled="!selectedProvince">
-                  <SelectTrigger id="edit-city">
-                    <SelectValue placeholder="Select city/municipality" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectGroup>
-                      <SelectLabel>Cities/Municipalities</SelectLabel>
-                      <SelectItem 
-                        v-for="city in filteredCities" 
-                        :key="city.city_code"
-                        :value="city.city_code"
-                      >
-                        {{ city.city_name }}
-                      </SelectItem>
-                    </SelectGroup>
-                  </SelectContent>
-                </Select>
-                <p v-if="!selectedProvince" class="text-xs text-muted-foreground">
-                  Select a province first
-                </p>
-              </div>
-
-              <!-- Barangay Selection -->
-              <div class="space-y-2">
-                <Label for="edit-barangay">Barangay</Label>
-                <Select v-model="selectedBarangay" :disabled="!selectedCity">
-                  <SelectTrigger id="edit-barangay">
-                    <SelectValue placeholder="Select barangay" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectGroup>
-                      <SelectLabel>Barangays</SelectLabel>
-                      <SelectItem 
-                        v-for="barangay in filteredBarangays" 
-                        :key="barangay.brgy_code"
-                        :value="barangay.brgy_code"
-                      >
-                        {{ barangay.brgy_name }}
-                      </SelectItem>
-                    </SelectGroup>
-                  </SelectContent>
-                </Select>
-                <p v-if="!selectedCity" class="text-xs text-muted-foreground">
-                  Select a city/municipality first
-                </p>
-              </div>
-
-              <!-- Street Address -->
-              <div class="space-y-2 sm:col-span-2">
-                <Label for="edit-street">Street Address</Label>
-                <Input
-                  id="edit-street"
-                  v-model="editForm.street"
-                  placeholder="Enter house/building number and street name"
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <DialogFooter>
-          <Button variant="outline" @click="handleCancelEdit">
-            Cancel
-          </Button>
-          <Button @click="handleSaveProfile">
-            Save Changes
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+    <EditProfileDialog
+      v-model:open="isEditDialogOpen"
+      :user="user"
+      :is-saving="isSaving"
+      @save="handleSaveProfile"
+      @cancel="handleCancelEdit"
+    />
   </div>
 </template>

--- a/client/src/stores/auth.js
+++ b/client/src/stores/auth.js
@@ -106,6 +106,50 @@ export const useAuthStore = defineStore('auth', () => {
     localStorage.removeItem('street')
     localStorage.removeItem('country')
   }
+
+  function updateProfile(userData) {
+    // Update state with new user data
+    if (userData.name !== undefined) {
+      userName.value = userData.name
+      localStorage.setItem('userName', userData.name)
+    }
+    
+    if (userData.region !== undefined) {
+      region.value = userData.region
+      if (userData.region) localStorage.setItem('region', userData.region)
+      else localStorage.removeItem('region')
+    }
+    
+    if (userData.province !== undefined) {
+      province.value = userData.province
+      if (userData.province) localStorage.setItem('province', userData.province)
+      else localStorage.removeItem('province')
+    }
+    
+    if (userData.city !== undefined) {
+      city.value = userData.city
+      if (userData.city) localStorage.setItem('city', userData.city)
+      else localStorage.removeItem('city')
+    }
+    
+    if (userData.barangay !== undefined) {
+      barangay.value = userData.barangay
+      if (userData.barangay) localStorage.setItem('barangay', userData.barangay)
+      else localStorage.removeItem('barangay')
+    }
+    
+    if (userData.street !== undefined) {
+      street.value = userData.street
+      if (userData.street) localStorage.setItem('street', userData.street)
+      else localStorage.removeItem('street')
+    }
+    
+    if (userData.profilePicture !== undefined) {
+      profilePicture.value = userData.profilePicture
+      if (userData.profilePicture) localStorage.setItem('profilePicture', userData.profilePicture)
+      else localStorage.removeItem('profilePicture')
+    }
+  }
   
   function getAuthHeader() {
     return token.value ? { Authorization: `Bearer ${token.value}` } : {}
@@ -131,6 +175,7 @@ export const useAuthStore = defineStore('auth', () => {
     // Actions
     login,
     logout,
+    updateProfile,
     getAuthHeader
   }
 })

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -1,6 +1,7 @@
 import express from 'express';
 // Import the Prisma client initialized in db.js
 import prisma from '../db.js'; 
+import { authenticateToken } from '../middleware/auth.js';
 
 const router = express.Router();
     
@@ -37,6 +38,90 @@ router.get('/test-connection', async (req, res) => {
         res.status(500).json({ 
             status: 'ERROR', 
             error: "Server or Database connection failed. See server console for details." 
+        });
+    }
+});
+
+/**
+ * @route PATCH /api/user/profile
+ * @description Update user profile information
+ * @access Private (requires valid JWT)
+ * @body {string} name - User's full name
+ * @body {string} region - Region name
+ * @body {string} province - Province name
+ * @body {string} city - City/Municipality name
+ * @body {string} barangay - Barangay name
+ * @body {string} street - Street address
+ * @returns {object} 200 - Updated user data
+ * @returns {object} 400 - Validation errors
+ * @returns {object} 401 - Unauthorized
+ * @returns {object} 404 - User not found
+ * @returns {object} 500 - Internal server error
+ */
+router.patch('/user/profile', authenticateToken, async (req, res) => {
+    try {
+        const userId = req.user.id; // From auth middleware (user object has 'id' not 'userId')
+        const { name, region, province, city, barangay, street } = req.body;
+
+        // Validation
+        if (!name || name.trim().length === 0) {
+            return res.status(400).json({
+                error: 'Name is required'
+            });
+        }
+
+        if (name.trim().length < 2) {
+            return res.status(400).json({
+                error: 'Name must be at least 2 characters long'
+            });
+        }
+
+        // Check if user exists
+        const existingUser = await prisma.user.findUnique({
+            where: { id: userId }
+        });
+
+        if (!existingUser) {
+            return res.status(404).json({
+                error: 'User not found'
+            });
+        }
+
+        // Update user profile
+        const updatedUser = await prisma.user.update({
+            where: { id: userId },
+            data: {
+                name: name.trim(),
+                region: region?.trim() || null,
+                province: province?.trim() || null,
+                city: city?.trim() || null,
+                barangay: barangay?.trim() || null,
+                street: street?.trim() || null,
+            },
+            select: {
+                id: true,
+                email: true,
+                name: true,
+                role: true,
+                profilePicture: true,
+                region: true,
+                province: true,
+                city: true,
+                barangay: true,
+                street: true,
+                country: true,
+                createdAt: true,
+            }
+        });
+
+        res.status(200).json({
+            message: 'Profile updated successfully',
+            user: updatedUser
+        });
+    } catch (error) {
+        console.error('Profile update error:', error);
+        res.status(500).json({
+            error: 'Failed to update profile'
         });
     }
 });


### PR DESCRIPTION
- Extract ProfileDisplay component (177 lines) for displaying user profile info
- Extract EditProfileDialog component (353 lines) for profile editing with Philippine address cascading
- Reduce ProfileTab from 612 to 107 lines (82% reduction)
- Improve maintainability, reusability, and testability
- Preserve all existing functionality (validation, API calls, toast notifications)
- Add sonner toast library for better notifications
- Update API endpoint and auth store for profile updates