### PR TITLE
feat: implement secure account deletion with password verification and admin restrictions

### DIFF
--- a/client/src/api/index.js
+++ b/client/src/api/index.js
@@ -37,27 +37,28 @@ api.interceptors.response.use(
     if (error.response?.status === 401) {
       const errorCode = error.response?.data?.error
       
-      // Check if it's an expired token
+      // Only auto-logout for session-related errors, not for invalid credentials
       if (errorCode === 'EXPIRED_TOKEN') {
         toast.error('Session Expired', {
           description: 'Your session has expired. Please log in again.'
         })
+        
+        // Clear auth state and redirect
+        const authStore = useAuthStore()
+        authStore.logout()
+        router.push('/auth/login')
       } else if (errorCode === 'SESSION_TERMINATED') {
         toast.error('Session Terminated', {
           description: 'This session was logged out from another device.'
         })
-      } else {
-        toast.error('Authentication Failed', {
-          description: 'Please log in to continue.'
-        })
+        
+        // Clear auth state and redirect
+        const authStore = useAuthStore()
+        authStore.logout()
+        router.push('/auth/login')
       }
-      
-      // Clear auth state
-      const authStore = useAuthStore()
-      authStore.logout()
-      
-      // Redirect to login page
-      router.push('/auth/login')
+      // For INVALID_PASSWORD and other 401 errors, just pass through to component
+      // Don't auto-logout as it might be user error (wrong password, etc.)
     }
     return Promise.reject(error)
   }

--- a/client/src/api/profile.js
+++ b/client/src/api/profile.js
@@ -1,4 +1,4 @@
-import axios from './index'
+import api from './index'
 
 /**
  * Profile API endpoints
@@ -9,6 +9,19 @@ import axios from './index'
  * @returns {Promise} Promise containing user data (profile, address, sessions, metadata)
  */
 export const exportUserData = async () => {
-  const response = await axios.get('/user/export')
+  const response = await api.get('/user/export')
+  return response.data
+}
+
+/**
+ * Delete user account
+ * @param {Object} data - Account deletion data
+ * @param {string} data.password - User's current password
+ * @param {string} data.confirmationWord - The randomly generated confirmation word
+ * @param {string} data.providedWord - The word typed by the user
+ * @returns {Promise} Promise containing deletion confirmation
+ */
+export const deleteAccount = async (data) => {
+  const response = await api.delete('/user/account', { data })
   return response.data
 }

--- a/client/src/components/views/profile/DeleteAccountTab.vue
+++ b/client/src/components/views/profile/DeleteAccountTab.vue
@@ -1,5 +1,9 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { toast } from 'vue-sonner'
+import { useAuthStore } from '@/stores/auth'
+import { deleteAccount } from '@/api/profile'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -9,18 +13,98 @@ import { Alert, AlertDescription } from '@/components/ui/alert'
 import {
   Trash2,
   AlertTriangle,
+  Copy,
+  CheckCircle,
 } from 'lucide-vue-next'
 
-// Delete account state
-const deleteConfirmation = ref('')
-const showDeleteWarning = ref(false)
+// Router and stores
+const router = useRouter()
+const authStore = useAuthStore()
 
-// Actions
-const handleDeleteAccount = () => {
-  if (deleteConfirmation.value === 'DELETE') {
-    // To be implemented
-    console.log('Account deletion initiated')
+// User role checking
+const isAdmin = computed(() => authStore.userRole === 'admin')
+
+// Delete account state
+const password = ref('')
+const confirmationWord = ref('')
+const providedWord = ref('')
+const showDeleteWarning = ref(false)
+const isDeleting = ref(false)
+const wordCopied = ref(false)
+
+// Generate random confirmation word
+const generateConfirmationWord = () => {
+  const words = [
+    'sunset', 'ocean', 'mountain', 'forest', 'river', 'desert',
+    'galaxy', 'thunder', 'crystal', 'phoenix', 'dragon', 'falcon',
+    'cosmos', 'nebula', 'meteor', 'comet', 'planet', 'stellar'
+  ]
+  return words[Math.floor(Math.random() * words.length)]
+}
+
+// Initialize confirmation word on mount
+onMounted(() => {
+  confirmationWord.value = generateConfirmationWord()
+})
+
+// Form validation
+const isFormValid = computed(() => {
+  return password.value.trim() !== '' && 
+         providedWord.value.trim() !== '' &&
+         providedWord.value.toLowerCase() === confirmationWord.value.toLowerCase()
+})
+
+// Actions  
+const handleDeleteAccount = async () => {
+  if (!isFormValid.value) {
+    toast.error('Please fill in all required fields correctly')
+    return
   }
+
+  isDeleting.value = true
+
+  try {
+    const response = await deleteAccount({
+      password: password.value,
+      confirmationWord: confirmationWord.value,
+      providedWord: providedWord.value
+    })
+
+    // Only proceed with logout if deletion was successful
+    if (response) {
+      toast.success('Account deleted successfully')
+      
+      // Clear authentication and redirect to login
+      await authStore.logout()
+      
+      setTimeout(() => {
+        router.push('/auth/login')
+      }, 1500)
+    }
+  } catch (error) {
+    console.error('Delete account error:', error)
+    
+    if (error.response?.data?.error === 'ADMIN_DELETE_RESTRICTED') {
+      toast.error('Admins cannot delete their own accounts. Please contact developers.', {
+        duration: 5000
+      })
+    } else if (error.response?.data?.error === 'INVALID_PASSWORD') {
+      toast.error('Current password is incorrect')
+    } else if (error.response?.data?.error === 'INVALID_CONFIRMATION') {
+      toast.error('Confirmation word does not match')
+    } else {
+      toast.error(error.response?.data?.message || 'Failed to delete account')
+    }
+  } finally {
+    isDeleting.value = false
+  }
+}
+
+const resetForm = () => {
+  showDeleteWarning.value = false
+  password.value = ''
+  providedWord.value = ''
+  confirmationWord.value = generateConfirmationWord()
 }
 </script>
 
@@ -34,7 +118,16 @@ const handleDeleteAccount = () => {
         </CardDescription>
       </CardHeader>
       <CardContent class="space-y-6">
-        <Alert variant="destructive">
+        <!-- Admin Warning -->
+        <Alert v-if="isAdmin" variant="destructive">
+          <AlertTriangle class="h-4 w-4" />
+          <AlertDescription>
+            <strong>Administrator Account:</strong> Admins cannot delete their own accounts for security reasons. Please contact the development team if you need to delete your account.
+          </AlertDescription>
+        </Alert>
+
+        <!-- General Warning -->
+        <Alert v-else variant="destructive">
           <AlertTriangle class="h-4 w-4" />
           <AlertDescription>
             <strong>Warning:</strong> This action cannot be undone. This will permanently delete your account and remove your data from our servers.
@@ -58,58 +151,115 @@ const handleDeleteAccount = () => {
             </li>
             <li class="flex items-start gap-2">
               <span class="text-destructive mt-0.5">•</span>
-              <span>Any active subscriptions or services will be cancelled</span>
+              <span>All active sessions will be terminated</span>
             </li>
           </ul>
         </div>
 
         <Separator />
 
-        <div v-if="!showDeleteWarning" class="flex justify-start">
+        <!-- Admin Restriction Message -->
+        <div v-if="isAdmin" class="p-4 bg-muted rounded-lg border border-border">
+          <div class="flex items-start gap-3">
+            <AlertTriangle class="h-5 w-5 text-amber-500 mt-0.5 shrink-0" />
+            <div class="space-y-1">
+              <p class="text-sm font-medium">Account Deletion Restricted</p>
+              <p class="text-sm text-muted-foreground">
+                Administrator accounts cannot be deleted for security and system integrity purposes. 
+                If you need to delete your admin account, please contact the development team at 
+                <a href="mailto:synera.swe@gmail.com" class="text-primary hover:underline">synera.swe@gmail.com</a>
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Initial Delete Button (Non-Admin Only) -->
+        <div v-else-if="!showDeleteWarning" class="flex justify-start">
           <Button 
             @click="showDeleteWarning = true" 
             variant="outline" 
-            class="text-destructive border-destructive hover:bg-destructive hover:text-destructive-foreground gap-2"
+            class="text-destructive border-destructive hover:bg-destructive hover:text-white gap-2"
           >
             <Trash2 class="h-4 w-4" />
             I want to delete my account
           </Button>
         </div>
 
-        <div v-else class="space-y-4">
+        <!-- Delete Confirmation Form -->
+        <div v-else class="space-y-6">
           <Alert variant="destructive">
             <AlertTriangle class="h-4 w-4" />
             <AlertDescription>
-              Please type <strong>DELETE</strong> to confirm account deletion
+              To proceed with account deletion, you must verify your identity by providing your current password and typing the randomly generated confirmation word.
             </AlertDescription>
           </Alert>
 
+          <!-- Password Input -->
           <div class="space-y-2">
-            <Label for="delete-confirmation">Confirmation</Label>
+            <Label for="password">Current Password <span class="text-destructive">*</span></Label>
             <Input
-              id="delete-confirmation"
-              v-model="deleteConfirmation"
-              placeholder="Type DELETE to confirm"
+              id="password"
+              v-model="password"
+              type="password"
+              placeholder="Enter your current password"
               class="border-destructive focus-visible:ring-destructive"
+              :disabled="isDeleting"
             />
           </div>
 
+          <!-- Confirmation Word Display -->
+          <div class="space-y-2">
+            <Label>Confirmation Word</Label>
+            <div class="flex gap-2">
+              <div class="flex-1 p-3 bg-muted rounded-md font-mono text-lg font-semibold text-center border-2 border-destructive select-none" inert="true">
+                {{ confirmationWord }}
+              </div>
+            </div>
+            <p class="text-xs text-muted-foreground">
+              Copy this word and type it in the field below to confirm deletion
+            </p>
+          </div>
+
+          <!-- Confirmation Word Input -->
+          <div class="space-y-2">
+            <Label for="provided-word">Type the confirmation word <span class="text-destructive">*</span></Label>
+            <Input
+              id="provided-word"
+              v-model="providedWord"
+              type="text"
+              placeholder="Type the confirmation word"
+              class="border-destructive focus-visible:ring-destructive"
+              :disabled="isDeleting"
+            />
+            <p v-if="providedWord && providedWord.toLowerCase() !== confirmationWord.toLowerCase()" 
+               class="text-xs text-destructive">
+              Confirmation word does not match
+            </p>
+            <p v-else-if="providedWord && providedWord.toLowerCase() === confirmationWord.toLowerCase()" 
+               class="text-xs text-green-600">
+              Confirmation word matches
+            </p>
+          </div>
+
+          <!-- Action Buttons -->
           <div class="flex gap-3">
             <Button 
-              @click="showDeleteWarning = false; deleteConfirmation = ''" 
+              @click="resetForm" 
               variant="outline"
               class="flex-1"
+              :disabled="isDeleting"
             >
               Cancel
             </Button>
             <Button 
               @click="handleDeleteAccount"
-              :disabled="deleteConfirmation !== 'DELETE'"
+              :disabled="!isFormValid || isDeleting"
               variant="destructive"
               class="flex-1 gap-2"
             >
-              <Trash2 class="h-4 w-4" />
-              Delete Account
+              <Trash2 v-if="!isDeleting" class="h-4 w-4" />
+              <span v-if="isDeleting">Deleting...</span>
+              <span v-else>Delete Account Permanently</span>
             </Button>
           </div>
         </div>


### PR DESCRIPTION

- Add DELETE /api/user/account endpoint with bcrypt password validation
- Implement random word confirmation for account deletion
- Add role-based restrictions (admins cannot self-delete)
- Create deleteAccount API function in profile.js
- Update DeleteAccountTab.vue with password input and confirmation word
- Add admin restriction message with contact information
- Fix axios interceptor to not auto-logout on invalid password errors
- Only auto-logout for session-related errors (EXPIRED_TOKEN, SESSION_TERMINATED)
- Delete all user sessions before account deletion
- Proper error handling for INVALID_PASSWORD, INVALID_CONFIRMATION, and ADMIN_DELETE_RESTRICTED