### PR TITLE
feat: implement URL query parameter navigation for profile tabs

### DIFF
--- a/client/src/components/ui/tabs/Tabs.vue
+++ b/client/src/components/ui/tabs/Tabs.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { provide, ref } from 'vue'
+import { provide, ref, watch } from 'vue'
 import { cn } from '@/lib/utils'
 
 const props = defineProps({
@@ -7,16 +7,31 @@ const props = defineProps({
     type: String,
     required: true
   },
+  modelValue: {
+    type: String,
+    default: null
+  },
   class: {
     type: String,
     default: ''
   }
 })
 
-const activeTab = ref(props.defaultValue)
+const emit = defineEmits(['update:modelValue'])
+
+// Use modelValue if provided, otherwise use defaultValue
+const activeTab = ref(props.modelValue || props.defaultValue)
+
+// Watch for external changes to modelValue
+watch(() => props.modelValue, (newValue) => {
+  if (newValue && newValue !== activeTab.value) {
+    activeTab.value = newValue
+  }
+})
 
 const setActiveTab = (value) => {
   activeTab.value = value
+  emit('update:modelValue', value)
 }
 
 provide('activeTab', activeTab)

--- a/client/src/pages/dashboard/Profile.vue
+++ b/client/src/pages/dashboard/Profile.vue
@@ -1,4 +1,6 @@
 <script setup>
+import { ref, watch, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import ProfileTab from '@/components/views/profile/ProfileTab.vue'
 import SecurityTab from '@/components/views/profile/SecurityTab.vue'
@@ -10,6 +12,44 @@ import {
   Download,
   Trash2,
 } from 'lucide-vue-next'
+
+const route = useRoute()
+const router = useRouter()
+
+// Valid tab values
+const validTabs = ['profile', 'security', 'data', 'delete']
+
+// Get initial tab from URL query parameter or default to 'profile'
+const getInitialTab = () => {
+  const tabParam = route.query.tab
+  return validTabs.includes(tabParam) ? tabParam : 'profile'
+}
+
+const currentTab = ref(getInitialTab())
+
+// Update URL when tab changes
+const handleTabChange = (newTab) => {
+  if (newTab && validTabs.includes(newTab)) {
+    router.push({ query: { tab: newTab } })
+  }
+}
+
+// Watch for URL changes (e.g., browser back/forward)
+watch(() => route.query.tab, (newTab) => {
+  if (newTab && validTabs.includes(newTab)) {
+    currentTab.value = newTab
+  } else if (!newTab) {
+    currentTab.value = 'profile'
+    router.replace({ query: { tab: 'profile' } })
+  }
+})
+
+// Set initial URL if no tab parameter exists
+onMounted(() => {
+  if (!route.query.tab) {
+    router.replace({ query: { tab: 'profile' } })
+  }
+})
 </script>
 
 <template>
@@ -23,7 +63,12 @@ import {
     </div>
 
     <!-- Tabs -->
-    <Tabs default-value="profile" class="space-y-6">
+    <Tabs 
+      v-model="currentTab" 
+      :default-value="currentTab"
+      @update:model-value="handleTabChange" 
+      class="space-y-6"
+    >
       <TabsList class="grid w-full grid-cols-4 lg:w-auto">
         <TabsTrigger value="profile">
           <User class="h-4 w-4 mr-2" />


### PR DESCRIPTION
- Add v-model support to Tabs component with modelValue prop and emit
- Implement tab state synchronization with URL query parameters
- Add browser navigation support (back/forward buttons work correctly)
- Auto-redirect to ?tab=profile if no tab parameter is present
- Validate tab parameters to prevent invalid routes
- Enable direct URL access to specific tabs (e.g., /dashboard/profile?tab=security)
- Preserve active tab on page refresh
- Update Profile.vue to use reactive tab navigation with router integration