### PR TITLE
feat: AI Diagnostic Advisor + NLP documentation

### DIFF
--- a/NLP_FEATURES.md
+++ b/NLP_FEATURES.md
@@ -1,0 +1,215 @@
+# NLP Features — DADJ Auto Shop Management System
+
+This document describes the Natural Language Processing (NLP) features integrated into the system. Both features are powered by **Groq** running the **LLaMA 3.3 70B Versatile** model, chosen for its fast inference speed and strong instruction-following capability.
+
+---
+
+## Overview
+
+| Feature | Input Method | Output | Where |
+|---|---|---|---|
+| Voice Order Assistant | Speech (microphone) | Customer name, vehicle, service items | New Service Order page |
+| AI Diagnostic Advisor | Text (typed complaint) | Diagnoses, recommended service items | New Service Order page |
+
+Both features share the same downstream effect: they pre-fill the service order items builder so staff spend less time typing and more time on actual work.
+
+---
+
+## Feature 1 — Voice Order Assistant
+
+### What it does
+
+Staff speak a service order description in natural language. The system transcribes the speech, sends it to the AI, and extracts structured data that is applied directly to the form.
+
+### Example
+
+> *"New job for Juan dela Cruz's Honda Civic. Replace brake pads, 4 sets at 500 pesos each. Two hours of labor at 350 pesos per hour."*
+
+The AI returns:
+```json
+{
+  "customerName": "Juan dela Cruz",
+  "vehicleDescription": "Honda Civic",
+  "items": [
+    { "type": "PART",  "name": "Brake pads", "quantity": 4, "price": 500 },
+    { "type": "LABOR", "name": "Labor",       "quantity": 2, "price": 350 }
+  ]
+}
+```
+
+After tapping **Apply to Form**:
+- The system searches the customer database for "Juan dela Cruz" using a name-splitting algorithm (searches last name, then filters by first name)
+- The best matching vehicle is selected using a scoring heuristic (make, model, plate, year)
+- All items are pushed into the order builder
+
+### How it works
+
+```
+Microphone (Capacitor SpeechRecognition)
+  → partialResults events update live transcript
+  → listeningState: stopped fires after final result
+  → stopListening() calls POST /api/ai/parse-order
+  → Groq LLaMA 3.3 extracts structured JSON
+  → applyVoiceOrder() fills customer, vehicle, items
+```
+
+### Technical notes
+
+- Uses `@capacitor-community/speech-recognition` for on-device speech capture on Android
+- A `stoppingInProgress` mutex prevents double-stop race conditions
+- All Capacitor calls are wrapped in `withTimeout()` to prevent hangs if Android stops recognition internally
+- API requests use `?t=Date.now()` cache-busting to prevent Android WebView from serving stale cached responses
+- Customer search handles Filipino name formats (e.g. "Juan Dela Cruz" → searches "Dela Cruz", filters by "Juan")
+
+### API Endpoint
+
+```
+POST /api/ai/parse-order
+Authorization: Bearer <token>
+
+Body: { "transcript": "..." }
+
+Response: {
+  "parsed": {
+    "customerName": "...",
+    "vehicleDescription": "...",
+    "items": [{ "type": "PART|LABOR", "name": "...", "quantity": 1, "price": 0 }]
+  }
+}
+```
+
+---
+
+## Feature 2 — AI Diagnostic Advisor
+
+### What it does
+
+Staff type a customer's complaint in plain English. The AI analyzes the symptoms like an experienced mechanic and returns likely diagnoses ranked by confidence, plus a recommended list of service items (parts and labor) with estimated prices in PHP.
+
+### Example
+
+**Input:**
+```
+Vehicle: 2019 Toyota Vios
+Complaint: Car vibrates at high speed and pulls to the left when braking.
+           Grinding noise from the front wheels.
+```
+
+**Output:**
+```json
+{
+  "diagnoses": [
+    {
+      "issue": "Worn brake pads / warped rotor",
+      "confidence": "high",
+      "explanation": "Grinding noise + pulling under braking is a classic sign of metal-on-metal contact and uneven rotor wear."
+    },
+    {
+      "issue": "Wheel imbalance",
+      "confidence": "medium",
+      "explanation": "High-speed vibration that disappears at lower speeds typically points to an out-of-balance wheel."
+    },
+    {
+      "issue": "Loose or worn wheel bearing",
+      "confidence": "low",
+      "explanation": "A rumbling/grinding that changes with steering input can indicate a failing wheel bearing."
+    }
+  ],
+  "items": [
+    { "type": "LABOR", "name": "Brake inspection",          "description": "Full front/rear check", "quantity": 1, "price": 300 },
+    { "type": "PART",  "name": "Brake pads (front)",        "description": "Semi-metallic",         "quantity": 1, "price": 900 },
+    { "type": "LABOR", "name": "Brake pad replacement",     "description": "Front axle",            "quantity": 2, "price": 400 },
+    { "type": "LABOR", "name": "Wheel balancing & rotation","description": "All four wheels",       "quantity": 1, "price": 500 }
+  ]
+}
+```
+
+The diagnoses are displayed as expandable cards ordered by confidence. Staff can review them and tap **Apply to Order** to push the suggested items directly into the order builder, then adjust prices and quantities as needed.
+
+### How it works
+
+```
+Staff types complaint + optional vehicle info
+  → POST /api/ai/diagnose
+  → Groq LLaMA 3.3 reasons about symptoms as a mechanic
+  → Returns diagnoses[] + items[] as JSON
+  → DiagnosticAdvisor.vue renders results in expandable cards
+  → Apply to Order emits items into EstimateItemBuilder
+```
+
+### Why LLM for this task
+
+Symptom-to-diagnosis mapping is not a keyword search problem. The same symptom ("grinding noise") can indicate brake pads, CV joints, wheel bearings, or a loose heat shield depending on context (speed, steering input, brake application). An LLM can reason across these conditions in natural language the same way an experienced mechanic would, without requiring a hand-crafted decision tree.
+
+### API Endpoint
+
+```
+POST /api/ai/diagnose
+Authorization: Bearer <token>
+
+Body: {
+  "complaint": "Car vibrates at high speed...",
+  "vehicleInfo": "2019 Toyota Vios"   (optional)
+}
+
+Response: {
+  "result": {
+    "diagnoses": [
+      { "issue": "...", "confidence": "high|medium|low", "explanation": "..." }
+    ],
+    "items": [
+      { "type": "PART|LABOR", "name": "...", "description": "...", "quantity": 1, "price": 0 }
+    ]
+  }
+}
+```
+
+---
+
+## Shared Infrastructure
+
+### AI Provider
+
+Both features use **Groq** (`groq-sdk`) with the `llama-3.3-70b-versatile` model.
+
+- Groq was chosen over Google Gemini due to superior availability (Gemini returns 503 errors under high demand)
+- `response_format: { type: 'json_object' }` enforces structured JSON output — no markdown fences or prose to strip
+- Temperature is kept low (0.1–0.2) so outputs are deterministic and consistent
+
+### Server setup (`server/routes/ai.js`)
+
+```js
+import Groq from 'groq-sdk'
+
+const groqClient = process.env.GROQ_API_KEY
+  ? new Groq({ apiKey: process.env.GROQ_API_KEY })
+  : null
+```
+
+The client is instantiated once at module load. If `GROQ_API_KEY` is missing, all endpoints return `503 AI service unavailable` immediately without attempting a network call.
+
+### Environment variables required
+
+| Variable | Purpose |
+|---|---|
+| `GROQ_API_KEY` | Required for Voice Order Assistant and Diagnostic Advisor |
+| `GEMINI_API_KEY` | Required for the Dashboard AI Insight card only |
+
+---
+
+## UI/UX Design Decisions
+
+- Both features use a **bottom sheet** pattern on mobile — consistent with native app conventions and avoids covering the form content
+- The Diagnostic Advisor uses an **amber color scheme** to visually distinguish it from the Voice Assistant (blue/primary)
+- Diagnoses are **expandable accordion cards** so the most important information (issue name + confidence) is always visible without cluttering the screen
+- Prices from the Diagnostic Advisor are labelled as *AI estimates* — the system never writes them as final without staff review
+- Example prompts are provided in the Diagnostic Advisor UI so users understand what kind of input produces good results
+
+---
+
+## Limitations and Known Behaviors
+
+- AI price estimates are based on general Philippine auto shop market rates trained into the model. They should always be reviewed before submitting an order.
+- The Voice Order Assistant requires an active microphone permission on the device. On Android, this is requested on first use via Capacitor.
+- The name-matching algorithm for customers works best when the spoken name matches the database spelling closely. If no match is found, the user is prompted to select manually.
+- Both features require an internet connection (Groq API calls are server-side).

--- a/client/src/components/ai/DiagnosticAdvisor.vue
+++ b/client/src/components/ai/DiagnosticAdvisor.vue
@@ -1,0 +1,268 @@
+<script setup>
+import { ref } from 'vue'
+import { Stethoscope, Loader2, CheckCircle, RotateCcw, ChevronDown, ChevronUp, Sparkles } from 'lucide-vue-next'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { Input } from '@/components/ui/input'
+import { Badge } from '@/components/ui/badge'
+import { toast } from 'vue-sonner'
+import api from '@/api'
+
+const emit = defineEmits(['apply'])
+
+const isOpen = ref(false)
+const complaint = ref('')
+const vehicleInfo = ref('')
+const isLoading = ref(false)
+const result = ref(null)
+const error = ref('')
+const expandedDiagnosis = ref(null)
+
+const confidenceVariant = (c) => ({ high: 'default', medium: 'secondary', low: 'outline' }[c] ?? 'outline')
+const confidenceLabel  = (c) => ({ high: 'High', medium: 'Medium', low: 'Low' }[c] ?? c)
+
+const open = () => {
+  isOpen.value = true
+  error.value = ''
+}
+
+const close = () => {
+  isOpen.value = false
+}
+
+const reset = () => {
+  result.value = null
+  error.value = ''
+  complaint.value = ''
+  vehicleInfo.value = ''
+  expandedDiagnosis.value = null
+}
+
+const analyze = async () => {
+  if (!complaint.value.trim()) {
+    toast.warning('Please describe the customer complaint first.')
+    return
+  }
+  isLoading.value = true
+  error.value = ''
+  result.value = null
+  expandedDiagnosis.value = null
+  toast.info('Analyzing complaint with AI...')
+  try {
+    const res = await api.post(`/ai/diagnose?t=${Date.now()}`, {
+      complaint: complaint.value,
+      vehicleInfo: vehicleInfo.value,
+    })
+    result.value = res.data.result
+    toast.success('Diagnosis ready! Review and apply to order.')
+  } catch (e) {
+    const msg = e.response?.data?.error || e.message || 'Failed to analyze. Please try again.'
+    error.value = msg
+    toast.error(msg)
+  } finally {
+    isLoading.value = false
+  }
+}
+
+const applyToOrder = () => {
+  if (!result.value?.items?.length) return
+  emit('apply', { items: result.value.items })
+  toast.success(`Applied ${result.value.items.length} suggested item(s) to order.`)
+  close()
+}
+</script>
+
+<template>
+  <!-- Trigger Button -->
+  <Button
+    type="button"
+    variant="outline"
+    class="gap-2 border-amber-400/50 text-amber-600 hover:bg-amber-50 hover:text-amber-700"
+    @click="open"
+  >
+    <Stethoscope class="h-4 w-4" />
+    <span class="hidden sm:inline">Diagnose</span>
+  </Button>
+
+  <!-- Bottom Sheet Overlay -->
+  <Teleport to="body">
+    <Transition name="sheet">
+      <div v-if="isOpen" class="fixed inset-0 z-50 flex flex-col justify-end">
+        <!-- Backdrop -->
+        <div class="absolute inset-0 bg-black/50" @click="close" />
+
+        <!-- Sheet -->
+        <div class="relative bg-background rounded-t-2xl shadow-xl max-h-[90vh] overflow-y-auto">
+          <!-- Handle bar -->
+          <div class="sticky top-0 bg-background pt-3 pb-2 px-6 z-10 border-b">
+            <div class="w-10 h-1 rounded-full bg-muted-foreground/30 mx-auto mb-3" />
+            <div class="flex items-center justify-between">
+              <div class="flex items-center gap-2">
+                <div class="h-8 w-8 rounded-lg bg-amber-100 flex items-center justify-center text-amber-600">
+                  <Stethoscope class="h-4 w-4" />
+                </div>
+                <div>
+                  <h2 class="text-base font-semibold leading-none">AI Diagnostic Advisor</h2>
+                  <p class="text-xs text-muted-foreground mt-0.5">Describe the problem, get suggested services</p>
+                </div>
+              </div>
+              <button @click="close" class="text-muted-foreground hover:text-foreground p-1">
+                <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+          </div>
+
+          <div class="p-6 space-y-5">
+            <!-- Input form -->
+            <div v-if="!result" class="space-y-4">
+              <div class="space-y-1.5">
+                <label class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Vehicle (optional)</label>
+                <Input
+                  v-model="vehicleInfo"
+                  placeholder="e.g. 2019 Toyota Vios, Honda Civic 2020"
+                  :disabled="isLoading"
+                />
+              </div>
+
+              <div class="space-y-1.5">
+                <label class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Customer Complaint <span class="text-destructive">*</span></label>
+                <Textarea
+                  v-model="complaint"
+                  placeholder="e.g. Car vibrates at high speed and pulls to the left when braking. Also hear a grinding noise from the front wheels."
+                  class="min-h-[100px] resize-none"
+                  :disabled="isLoading"
+                />
+              </div>
+
+              <Button class="w-full gap-2 bg-amber-600 hover:bg-amber-700 text-white" @click="analyze" :disabled="isLoading || !complaint.trim()">
+                <Loader2 v-if="isLoading" class="h-4 w-4 animate-spin" />
+                <Sparkles v-else class="h-4 w-4" />
+                {{ isLoading ? 'Analyzing...' : 'Analyze Complaint' }}
+              </Button>
+
+              <!-- Example prompts -->
+              <div v-if="!isLoading" class="space-y-1.5">
+                <p class="text-[11px] text-muted-foreground font-medium uppercase tracking-wider">Try an example</p>
+                <div class="flex flex-wrap gap-2">
+                  <button
+                    v-for="ex in [
+                      'Engine makes knocking noise on startup',
+                      'AC blows warm air only',
+                      'Car won\'t start, battery is fine',
+                      'Shakes when accelerating above 60 kph',
+                    ]"
+                    :key="ex"
+                    class="text-xs px-2.5 py-1 rounded-full border border-dashed border-amber-300 text-amber-700 bg-amber-50 hover:bg-amber-100 transition-colors"
+                    @click="complaint = ex"
+                  >
+                    {{ ex }}
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            <!-- Results -->
+            <div v-if="result" class="space-y-5">
+              <!-- Diagnoses -->
+              <div class="space-y-2">
+                <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Likely Diagnoses</p>
+                <div class="space-y-2">
+                  <div
+                    v-for="(d, i) in result.diagnoses"
+                    :key="i"
+                    class="border rounded-xl overflow-hidden bg-white shadow-sm"
+                  >
+                    <button
+                      class="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-slate-50 transition-colors"
+                      @click="expandedDiagnosis = expandedDiagnosis === i ? null : i"
+                    >
+                      <div class="flex items-center gap-3 min-w-0">
+                        <div class="h-6 w-6 rounded-full bg-amber-100 text-amber-700 flex items-center justify-center text-xs font-bold shrink-0">
+                          {{ i + 1 }}
+                        </div>
+                        <span class="font-semibold text-sm truncate">{{ d.issue }}</span>
+                      </div>
+                      <div class="flex items-center gap-2 shrink-0 ml-2">
+                        <Badge :variant="confidenceVariant(d.confidence)" class="text-[10px] px-1.5 capitalize">
+                          {{ confidenceLabel(d.confidence) }}
+                        </Badge>
+                        <ChevronDown v-if="expandedDiagnosis !== i" class="h-4 w-4 text-muted-foreground" />
+                        <ChevronUp v-else class="h-4 w-4 text-muted-foreground" />
+                      </div>
+                    </button>
+                    <div v-if="expandedDiagnosis === i" class="px-4 pb-3 text-sm text-muted-foreground border-t bg-slate-50/50">
+                      <p class="pt-2">{{ d.explanation }}</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Suggested Items -->
+              <div class="space-y-2">
+                <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Suggested Service Items ({{ result.items?.length || 0 }})</p>
+                <div class="border rounded-xl overflow-hidden bg-white shadow-sm divide-y">
+                  <div
+                    v-for="(item, i) in result.items"
+                    :key="i"
+                    class="flex items-center gap-3 px-4 py-3"
+                  >
+                    <Badge
+                      variant="outline"
+                      :class="item.type === 'PART' ? 'border-blue-200 text-blue-700 bg-blue-50' : 'border-amber-200 text-amber-700 bg-amber-50'"
+                      class="text-[10px] shrink-0"
+                    >
+                      {{ item.type }}
+                    </Badge>
+                    <div class="flex-1 min-w-0">
+                      <p class="text-sm font-medium truncate">{{ item.name }}</p>
+                      <p v-if="item.description" class="text-xs text-muted-foreground truncate">{{ item.description }}</p>
+                    </div>
+                    <div class="text-right shrink-0">
+                      <p class="text-sm font-semibold">₱{{ Number(item.price).toLocaleString() }}</p>
+                      <p class="text-[10px] text-muted-foreground">× {{ item.quantity }}</p>
+                    </div>
+                  </div>
+                </div>
+                <p class="text-[10px] text-muted-foreground px-1">Prices are AI estimates. Adjust as needed after applying.</p>
+              </div>
+
+              <!-- Actions -->
+              <div class="flex gap-3 pt-1 pb-2">
+                <Button variant="outline" class="flex-1 gap-2" @click="reset">
+                  <RotateCcw class="h-4 w-4" />
+                  Try Again
+                </Button>
+                <Button class="flex-1 gap-2 bg-amber-600 hover:bg-amber-700 text-white" @click="applyToOrder" :disabled="!result.items?.length">
+                  <CheckCircle class="h-4 w-4" />
+                  Apply to Order
+                </Button>
+              </div>
+            </div>
+
+            <!-- Error -->
+            <div v-if="error" class="bg-destructive/10 border border-destructive/30 rounded-lg p-3 text-sm text-destructive">
+              {{ error }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.sheet-enter-active,
+.sheet-leave-active {
+  transition: opacity 0.2s ease;
+}
+.sheet-enter-active .relative,
+.sheet-leave-active .relative {
+  transition: transform 0.3s ease;
+}
+.sheet-enter-from,
+.sheet-leave-to {
+  opacity: 0;
+}
+</style>

--- a/client/src/pages/dashboard/service-orders/new.vue
+++ b/client/src/pages/dashboard/service-orders/new.vue
@@ -22,6 +22,7 @@ import EstimateItemBuilder from '@/components/views/estimates/EstimateItemBuilde
 import EstimateCustomerVehicleSelector from '@/components/views/estimates/EstimateCustomerVehicleSelector.vue'
 import EstimateSummary from '@/components/views/estimates/EstimateSummary.vue'
 import VoiceOrderAssistant from '@/components/voice/VoiceOrderAssistant.vue'
+import DiagnosticAdvisor from '@/components/ai/DiagnosticAdvisor.vue'
 
 const router = useRouter()
 const route = useRoute()
@@ -243,6 +244,20 @@ const applyVoiceOrder = async (data) => {
   }
 }
 
+const applyDiagnosis = (data) => {
+  if (data.items?.length) {
+    const newItems = data.items.map(item => ({
+      type: item.type || 'LABOR',
+      name: item.name || '',
+      description: item.description || '',
+      quantity: Number(item.quantity) || 1,
+      price: Number(item.price) || 0,
+      inventoryItemId: null,
+    }))
+    items.value.push(...newItems)
+  }
+}
+
 const saveOrder = async () => {
   if (!selectedCustomer.value || !selectedVehicleId.value || items.value.length === 0 || isDiscountExcessive.value) return
 
@@ -296,6 +311,7 @@ const saveOrder = async () => {
       </div>
       <!-- Desktop action buttons — hidden on mobile (mobile has sticky bar) -->
       <div class="hidden sm:flex flex-wrap gap-2">
+        <DiagnosticAdvisor @apply="applyDiagnosis" />
         <VoiceOrderAssistant @apply="applyVoiceOrder" />
         <Button variant="outline" @click="$router.back()">Cancel</Button>
         <Button
@@ -308,8 +324,9 @@ const saveOrder = async () => {
           Create Order
         </Button>
       </div>
-      <!-- Mobile: voice button only in header -->
-      <div class="flex sm:hidden">
+      <!-- Mobile: AI buttons in header -->
+      <div class="flex sm:hidden gap-2">
+        <DiagnosticAdvisor @apply="applyDiagnosis" />
         <VoiceOrderAssistant @apply="applyVoiceOrder" />
       </div>
     </div>

--- a/server/routes/ai.js
+++ b/server/routes/ai.js
@@ -154,4 +154,77 @@ Return ONLY this exact JSON shape:
     }
 })
 
+/**
+ * @route POST /api/ai/diagnose
+ * @description Analyze a customer complaint and suggest diagnoses + service items
+ * @access Private
+ */
+router.post('/diagnose', authenticateToken, async (req, res) => {
+    try {
+        const { complaint, vehicleInfo } = req.body
+
+        if (!complaint || typeof complaint !== 'string' || complaint.trim().length === 0) {
+            return res.status(400).json({ error: 'Complaint description is required' })
+        }
+
+        if (!groqClient) {
+            return res.status(503).json({ error: 'AI service unavailable' })
+        }
+
+        const vehicleContext = vehicleInfo ? `Vehicle: ${vehicleInfo.trim()}` : 'Vehicle: unknown'
+
+        const completion = await groqClient.chat.completions.create({
+            model: 'llama-3.3-70b-versatile',
+            messages: [
+                {
+                    role: 'system',
+                    content: `You are an expert automotive technician and service advisor for a repair shop in the Philippines.
+A customer has described a problem with their vehicle. Analyze the symptoms and return ONLY valid JSON — no explanation, no markdown, no code block.
+
+Rules:
+- diagnoses: up to 3 most likely root causes, ordered from most to least probable.
+  - issue: short name of the problem (e.g. "Worn brake pads")
+  - confidence: "high", "medium", or "low"
+  - explanation: 1–2 sentences explaining why this matches the symptoms
+- items: recommended service items to fix or investigate the issue.
+  - type: "LABOR" for services/inspections, "PART" for physical components
+  - name: specific service or part name
+  - description: brief detail (e.g. "Front and rear" or "Per hour")
+  - quantity: realistic number (hours for labor, units for parts)
+  - price: estimated price in PHP based on typical Philippine auto shop rates
+
+Return ONLY this exact JSON shape:
+{
+  "diagnoses": [
+    { "issue": "", "confidence": "high", "explanation": "" }
+  ],
+  "items": [
+    { "type": "LABOR", "name": "", "description": "", "quantity": 1, "price": 0 },
+    { "type": "PART",  "name": "", "description": "", "quantity": 1, "price": 0 }
+  ]
+}`
+                },
+                {
+                    role: 'user',
+                    content: `${vehicleContext}\nCustomer complaint: ${complaint.trim()}`
+                }
+            ],
+            temperature: 0.2,
+            response_format: { type: 'json_object' },
+        })
+
+        const text = completion.choices[0]?.message?.content || '{}'
+        const result = JSON.parse(text)
+
+        res.json({ result })
+
+    } catch (error) {
+        console.error('Diagnose Error:', error)
+        if (error instanceof SyntaxError) {
+            return res.status(422).json({ error: 'AI returned unparseable response. Try again.' })
+        }
+        res.status(500).json({ error: 'Failed to analyze complaint' })
+    }
+})
+
 export default router;


### PR DESCRIPTION
- Add DiagnosticAdvisor.vue: text-based complaint input, AI returns ranked diagnoses with confidence levels and expandable explanations, plus suggested service items (PART/LABOR) with PHP price estimates
- Integrate DiagnosticAdvisor into new service order page alongside VoiceOrderAssistant (amber color scheme, same Apply pattern)
- Add POST /api/ai/diagnose endpoint using Groq llama-3.3-70b-versatile with mechanic-role system prompt and JSON mode enforcement
- Add NLP_FEATURES.md documenting both NLP features: architecture, API contracts, design decisions, limitations, and example inputs/outputs